### PR TITLE
New pages for Advancement Types and link updates

### DIFF
--- a/wiki/Advancement-Type-Item-Choice.md
+++ b/wiki/Advancement-Type-Item-Choice.md
@@ -1,0 +1,36 @@
+![Up to date as of 2.2.0](https://img.shields.io/static/v1?label=dnd5e&message=2.0.0&color=informational)
+
+This advancement type is designed for any feature that gives the player a choice of options to add to their character at a certain level. This covers features with a limited set of options such as Fighting Style and more open ended features such as Magical Secrets.
+
+## Level Up Interface
+If a limited pool of options are provided, the interface will present the list with checkboxes so the player can select which options they would like. If any arbitrary items can be added, then the player is presented with a drop area where items can be dragged from the items sidebar or a compendium. Both a list of items and the drop area can be used at the same time.
+
+It should be clear how many choices are available (Fighting Style only allows one, Magical Secrets lets you take two, etc.).
+
+## Configuration
+
+![Item Choice Config](https://user-images.githubusercontent.com/19979839/177053250-967aa309-14bc-4f37-a243-9993a6a02a14.png)
+
+The `hint` text is a brief bit of text to assist players in what choices they can make. Typically this will be a portion of the feature's description and shouldn't be more than a single paragraph of one or two sentences.
+
+The `Choices` List on the right-hand side indicates how many choices are available to the player and at which levels. A choice that can be taken only once such as a Fighter's Fighting Style would be simple as { 1: 1 }, indicating that player should be presented with choosing a single style at first level. Something like Bard's Magical Secrets which gives the option of choosing two options at levels 10, 14, and 18 is shown below.
+
+The `Allow Drops` indicates whether the drop area should be shown to the player to allow arbitrary items to be added.
+
+Item types can be restricted using the `Type` field, which is null if any item type is acceptable, or can be set to one of the top-level types (except things like class, subclass, and background).
+
+Finally, the `pool` contains an array of item UUIDs indicating a fixed list of options presented to the player. When creating or modifying the Item Grant Advancement, drag-and-drop the items to present to the player to this section.
+
+## Player Experience
+
+Choosing from a list of options at level-up  
+
+https://user-images.githubusercontent.com/207433/240936902-4f5e3ce6-01e6-4634-9d8a-1aa27807192e.webm
+
+Dropping choices onto the Advancement  
+
+https://user-images.githubusercontent.com/207433/240936973-841f46e9-a842-44ce-9647-cc4a5fbcfccc.webm
+
+Making additional choices on top of those from a previous level  
+
+https://user-images.githubusercontent.com/207433/240937032-f18406e8-d8dd-46ab-b7b3-ff2d1aa97d87.webm

--- a/wiki/Advancement-Type-Item-Grant.md
+++ b/wiki/Advancement-Type-Item-Grant.md
@@ -1,0 +1,8 @@
+![Up to date as of 2.0.3](https://img.shields.io/static/v1?label=dnd5e&message=1.6.3&color=informational)
+
+This Advancement Type also contains the following options:
+* **Level**: Select the level that these features should be granted at.
+* **Optional**: If you want to give the user the option to decline any items granted by this Advancement, check this box, otherwise all items will be granted automatically.
+* **Items**: Drag and drop an item into this section for that item to be granted when an actor has reached the appropriate level in this class.
+
+![Item Grant Advancement Configuration](https://github.com/foundryvtt/dnd5e/assets/86370342/0121c15c-6a3d-4f16-957f-3c9b81b9674d)

--- a/wiki/Advancement-Type-Scale-Value.md
+++ b/wiki/Advancement-Type-Scale-Value.md
@@ -1,0 +1,22 @@
+![Up to date as of 2.0.3](https://img.shields.io/static/v1?label=dnd5e&message=1.6.3&color=informational)
+
+This Advancement Type also contains the following options:
+* **Scale Type**: This determines the values accepted on the Level sections on the right hand side
+* Anything - Allows an arbitrary input including text and numbers
+
+![Scale Value: Anything](https://github.com/foundryvtt/dnd5e/assets/86370342/3d20ec17-a88d-4398-b60a-bc7dda5a9fc0)
+
+* Dice - Allows a configuration of number of die and die size (options include d2, d3, d4, d6, d8, d10, d12, and d20). It is recommended for features that can use a variable number of these dice to leave the count blank, and define the number used in the feature, (e.g. `1@scale.monk.martial-arts`, `2@scale.monk.martial-arts`) this will ensure accurate values if used in the damage field and critical damage is rolled. Values that are a consistent number of die can have the value column populated (e.g. Sneak Attack)
+
+![Scale Value: Dice](https://github.com/foundryvtt/dnd5e/assets/86370342/80e49db5-8128-4edc-b2a9-3277ad7d8144)
+
+* Numeric - Allows a configuration of a number value in the level options
+
+![Scale Value: Numeric](https://github.com/foundryvtt/dnd5e/assets/86370342/f687de1a-c92e-4834-ac00-3170451b7129)
+
+* Distance - Allows for numerical values in the level options, you can choose the units of Feet, Miles, Meters, and Kilometers
+
+![Scale Value: Distance](https://github.com/foundryvtt/dnd5e/assets/86370342/496109c8-caa7-4185-97f4-bb84ab3a12eb)
+
+* **Identifier**: Defines the identifier to be used in a formula.
+* **1-20**: Used to define the scale value at a given level

--- a/wiki/Advancement-User-Guide.md
+++ b/wiki/Advancement-User-Guide.md
@@ -47,6 +47,10 @@ For more information, see [Hit Points Advancement](Advancement-Type-Hit-Points.m
 This advancement can grant another item on level up (e.g. Class Features, Equipment). It should not be used for Class Spellcasting as a separate Advancement type is planned for that. It can be used for Racial Spellcasting, however.  
 For more information, see [Item Grant Advancement](Advancement-Type-Item-Grant.md)
 
+## Item Choice
+This advancement type is designed for any feature that gives the player a choice of options to add to their character at a certain level. This covers features with a limited set of options such as Fighting Style and more open ended features such as Magical Secrets.  
+For more information, see [Item Choice Advancement](Advancement-Type-Item-Choice.md)
+
 ## Scale Value
 This can be used to track when features get extra uses (e.g. Wild Shape or Channel Divinity), or the die value of a feature increases (e.g. Sneak Attack or Martial Arts)
 For more information, see [Scale Value Advancement](Advancement-Type-Scale-Value.md)

--- a/wiki/Advancement-User-Guide.md
+++ b/wiki/Advancement-User-Guide.md
@@ -43,37 +43,12 @@ This advancement item will prompt for the user to Roll for HP or use the average
 For more information, see [Hit Points Advancement](Advancement-Type-Hit-Points.md)
 
 ## Item Grant
-This advancement can grant another item on level up (e.g. Class Features, Equipment). It should not be used for Class Spellcasting as a separate Advancement type is planned for that. It can be used for Racial Spellcasting, however.
-
-This Advancement Type also contains the following options:
-* **Level**: Select the level that these features should be granted at.
-* **Optional**: If you want to give the user the option to decline any items granted by this Advancement, check this box, otherwise all items will be granted automatically.
-* **Items**: Drag and drop an item into this section for that item to be granted when an actor has reached the appropriate level in this class.
-
-![Item Grant Advancement Configuration](https://github.com/foundryvtt/dnd5e/assets/86370342/0121c15c-6a3d-4f16-957f-3c9b81b9674d)
+This advancement can grant another item on level up (e.g. Class Features, Equipment). It should not be used for Class Spellcasting as a separate Advancement type is planned for that. It can be used for Racial Spellcasting, however.  
+For more information, see [Item Grant Advancement](Advancement-Type-Item Grant.md)
 
 ## Scale Value
 This can be used to track when features get extra uses (e.g. Wild Shape or Channel Divinity), or the die value of a feature increases (e.g. Sneak Attack or Martial Arts)
-This Advancement Type also contains the following options:
-* **Scale Type**: This determines the values accepted on the Level sections on the right hand side
-* Anything - Allows an arbitrary input including text and numbers
-
-![Scale Value: Anything](https://github.com/foundryvtt/dnd5e/assets/86370342/3d20ec17-a88d-4398-b60a-bc7dda5a9fc0)
-
-* Dice - Allows a configuration of number of die and die size (options include d2, d3, d4, d6, d8, d10, d12, and d20). It is recommended for features that can use a variable number of these dice to leave the count blank, and define the number used in the feature, (e.g. `1@scale.monk.martial-arts`, `2@scale.monk.martial-arts`) this will ensure accurate values if used in the damage field and critical damage is rolled. Values that are a consistent number of die can have the value column populated (e.g. Sneak Attack)
-
-![Scale Value: Dice](https://github.com/foundryvtt/dnd5e/assets/86370342/80e49db5-8128-4edc-b2a9-3277ad7d8144)
-
-* Numeric - Allows a configuration of a number value in the level options
-
-![Scale Value: Numeric](https://github.com/foundryvtt/dnd5e/assets/86370342/f687de1a-c92e-4834-ac00-3170451b7129)
-
-* Distance - Allows for numerical values in the level options, you can choose the units of Feet, Miles, Meters, and Kilometers
-
-![Scale Value: Distance](https://github.com/foundryvtt/dnd5e/assets/86370342/496109c8-caa7-4185-97f4-bb84ab3a12eb)
-
-* **Identifier**: Defines the identifier to be used in a formula.
-* **1-20**: Used to define the scale value at a given level
+For more information, see [Scale Value Advancement](Advancement-Type-Scale-Value.md)
 
 # Managing Class Levels on an Actor
 ## Adding a Class to an Actor

--- a/wiki/Advancement-User-Guide.md
+++ b/wiki/Advancement-User-Guide.md
@@ -44,7 +44,7 @@ For more information, see [Hit Points Advancement](Advancement-Type-Hit-Points.m
 
 ## Item Grant
 This advancement can grant another item on level up (e.g. Class Features, Equipment). It should not be used for Class Spellcasting as a separate Advancement type is planned for that. It can be used for Racial Spellcasting, however.  
-For more information, see [Item Grant Advancement](Advancement-Type-Item Grant.md)
+For more information, see [Item Grant Advancement](Advancement-Type-Item-Grant.md)
 
 ## Scale Value
 This can be used to track when features get extra uses (e.g. Wild Shape or Channel Divinity), or the die value of a feature increases (e.g. Sneak Attack or Martial Arts)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -6,6 +6,7 @@
     Advancement Types
     - [Advancement Type: Hit Points](Advancement-Type-Hit-Points.md)
     - [Advancement Type: Item Grant](Advancement-Type-Item-Grant.md)
+    - [Advancement Type: Item Choice](Advancement-Type-Item-Choice.md)
     - [Advancement Type: Scale Value](Advancement-Type-Scale-Value.md)
 
 - [Dynamic Module Art](Dynamic-Module-Art.md)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -5,6 +5,8 @@
   - [Custom Class Example](Custom-Class-Advancement.md)  
     Advancement Types
     - [Advancement Type: Hit Points](Advancement-Type-Hit-Points.md)
+    - [Advancement Type: Item Grant](Advancement-Type-Item-Grant.md)
+    - [Advancement Type: Scale Value](Advancement-Type-Scale-Value.md)
 - [Dynamic Module Art](Dynamic-Module-Art.md)
 - [Hooks](Hooks.md)
 - [Roll Formulas](Roll-Formulas.md)


### PR DESCRIPTION
Added new pages for each Advancement Type, and linked out to them from the User Guide
New documentation for Item Choice types with description from https://github.com/foundryvtt/dnd5e/issues/1401 and videos from the 2.0.0 release